### PR TITLE
Update ingress-srv.yaml

### DIFF
--- a/K8S/ingress-srv.yaml
+++ b/K8S/ingress-srv.yaml
@@ -3,9 +3,9 @@ kind: Ingress
 metadata:
   name: ingress-srv
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: 'true'
 spec:
+  ingressClassName: nginx
   rules:
     - host: ya.com
       http:


### PR DESCRIPTION
annotation "kubernetes.io/ingress.class" is deprecated, This was replace with 'spec.ingressClassName'.